### PR TITLE
Switch Jira search to new jql endpoint

### DIFF
--- a/src/JiraToRea.App/Models/JiraModels.cs
+++ b/src/JiraToRea.App/Models/JiraModels.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -16,6 +17,18 @@ public sealed class JiraSearchResponse
 {
     [JsonPropertyName("issues")]
     public List<JiraIssue> Issues { get; set; } = new();
+}
+
+public sealed class JiraSearchRequest
+{
+    [JsonPropertyName("jql")]
+    public string Jql { get; set; } = string.Empty;
+
+    [JsonPropertyName("fields")]
+    public IEnumerable<string> Fields { get; set; } = Array.Empty<string>();
+
+    [JsonPropertyName("maxResults")]
+    public int MaxResults { get; set; }
 }
 
 public sealed class JiraIssue

--- a/src/JiraToRea.App/Services/JiraApiClient.cs
+++ b/src/JiraToRea.App/Services/JiraApiClient.cs
@@ -83,8 +83,15 @@ public sealed class JiraApiClient : IDisposable
         }
 
         var jql = BuildJql(startDate, endDate);
-        var requestUri = $"rest/api/3/search?jql={Uri.EscapeDataString(jql)}&fields=summary&maxResults=200";
-        using var response = await _httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
+        var searchRequest = new JiraSearchRequest
+        {
+            Jql = jql,
+            Fields = new[] { "summary" },
+            MaxResults = 200
+        };
+
+        using var content = new StringContent(JsonSerializer.Serialize(searchRequest, _serializerOptions), Encoding.UTF8, "application/json");
+        using var response = await _httpClient.PostAsync("rest/api/3/search/jql", content, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
             var errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- update the Jira worklog search to call the new `/rest/api/3/search/jql` endpoint with a JSON payload
- add a request model used to serialize the search request body

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e37dee7898832284c1c2c426407839