### PR TITLE
Add credential persistence for future sessions

### DIFF
--- a/src/JiraToRea.App/MainForm.cs
+++ b/src/JiraToRea.App/MainForm.cs
@@ -541,14 +541,19 @@ public sealed class MainForm : Form
 
     protected override void OnFormClosed(FormClosedEventArgs e)
     {
-        base.OnFormClosed(e);
-        _settingsService.Save(new UserSettings
+        var settings = new UserSettings
         {
             ReaUsername = _reaUsernameTextBox.Text,
             ReaPassword = _reaPasswordTextBox.Text,
             JiraEmail = _jiraEmailTextBox.Text,
             JiraToken = _jiraTokenTextBox.Text
-        });
+        };
+
+        _userSettings = settings;
+
+        base.OnFormClosed(e);
+
+        _settingsService.Save(settings);
         _reaClient.Dispose();
         _jiraClient.Dispose();
     }

--- a/src/JiraToRea.App/Models/UserSettings.cs
+++ b/src/JiraToRea.App/Models/UserSettings.cs
@@ -1,0 +1,12 @@
+namespace JiraToRea.App.Models;
+
+public sealed class UserSettings
+{
+    public string ReaUsername { get; set; } = string.Empty;
+
+    public string ReaPassword { get; set; } = string.Empty;
+
+    public string JiraEmail { get; set; } = string.Empty;
+
+    public string JiraToken { get; set; } = string.Empty;
+}

--- a/src/JiraToRea.App/Services/UserSettingsService.cs
+++ b/src/JiraToRea.App/Services/UserSettingsService.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using System.Text.Json;
+using JiraToRea.App.Models;
+
+namespace JiraToRea.App.Services;
+
+public sealed class UserSettingsService
+{
+    private readonly string _settingsFilePath;
+
+    public UserSettingsService()
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        var folder = Path.Combine(appData, "JiraToRea");
+        Directory.CreateDirectory(folder);
+        _settingsFilePath = Path.Combine(folder, "settings.json");
+    }
+
+    public UserSettings Load()
+    {
+        try
+        {
+            if (File.Exists(_settingsFilePath))
+            {
+                var json = File.ReadAllText(_settingsFilePath);
+                if (!string.IsNullOrWhiteSpace(json))
+                {
+                    var settings = JsonSerializer.Deserialize<UserSettings>(json);
+                    if (settings != null)
+                    {
+                        return settings;
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // ignored - fallback to default settings
+        }
+
+        return new UserSettings();
+    }
+
+    public void Save(UserSettings settings)
+    {
+        try
+        {
+            var json = JsonSerializer.Serialize(settings);
+            File.WriteAllText(_settingsFilePath, json);
+        }
+        catch
+        {
+            // ignored - best effort persistence
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- load stored user credentials when the application starts and pre-fill the login fields
- persist the latest Rea and Jira credentials to a user-specific settings file on close
- add a lightweight settings service and model to manage credential storage

## Testing
- attempted to run `dotnet build` *(fails: `dotnet` command is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e383c327c08322910acb5c7764fa6d