### PR TITLE
Create tabbed worklog statistics dialog

### DIFF
--- a/src/JiraToRea.App/MainForm.cs
+++ b/src/JiraToRea.App/MainForm.cs
@@ -32,6 +32,7 @@ public sealed class MainForm : Form
     private readonly DateTimePicker _endDatePicker;
     private readonly Button _findButton;
     private readonly Button _importButton;
+    private readonly Button _statisticsButton;
     private readonly DataGridView _worklogGrid;
     private readonly Label _selectionLabel;
     private readonly Label _statusLabel;
@@ -52,6 +53,8 @@ public sealed class MainForm : Form
         };
 
         Controls.Add(mainPanel);
+
+        _worklogEntries.ListChanged += (_, _) => UpdateStatisticsButtonState();
 
         var reaGroup = new GroupBox
         {
@@ -188,11 +191,17 @@ public sealed class MainForm : Form
         _findButton.Location = new Point(710, 18);
         _findButton.Width = 100;
 
+        _statisticsButton = CreateButton("Meraklısına İstatistik", StatisticsButton_Click);
+        _statisticsButton.Location = new Point(820, 18);
+        _statisticsButton.Width = 180;
+        _statisticsButton.Enabled = false;
+
         mainPanel.Controls.Add(new Label { Text = "Start Date", Location = new Point(330, 0), AutoSize = true });
         mainPanel.Controls.Add(_startDatePicker);
         mainPanel.Controls.Add(new Label { Text = "End Date", Location = new Point(520, 0), AutoSize = true });
         mainPanel.Controls.Add(_endDatePicker);
         mainPanel.Controls.Add(_findButton);
+        mainPanel.Controls.Add(_statisticsButton);
 
         _worklogGrid = new DataGridView
         {
@@ -301,6 +310,8 @@ public sealed class MainForm : Form
 
         _startDatePicker.Value = DateTime.Today.AddDays(-7);
         _endDatePicker.Value = DateTime.Today;
+
+        UpdateStatisticsButtonState();
     }
 
     private static TextBox CreateTextBox(string text)
@@ -534,6 +545,11 @@ public sealed class MainForm : Form
         _importButton.Enabled = _reaClient.IsAuthenticated && hasSelection && hasProject;
     }
 
+    private void UpdateStatisticsButtonState()
+    {
+        _statisticsButton.Enabled = _worklogEntries.Count > 0;
+    }
+
     private void SetStatus(string message)
     {
         _statusLabel.Text = message;
@@ -579,5 +595,17 @@ public sealed class MainForm : Form
         {
             UpdateImportButtonState();
         }
+    }
+
+    private void StatisticsButton_Click(object? sender, EventArgs e)
+    {
+        if (_worklogEntries.Count == 0)
+        {
+            MessageBox.Show(this, "İstatistik oluşturmak için kayıt bulunmuyor.", "Bilgi", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        using var statisticsForm = new WorklogStatisticsForm(_worklogEntries.ToList());
+        statisticsForm.ShowDialog(this);
     }
 }

--- a/src/JiraToRea.App/WorklogStatisticsForm.cs
+++ b/src/JiraToRea.App/WorklogStatisticsForm.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Globalization;
+using System.Linq;
+using System.Windows.Forms;
+using JiraToRea.App.Models;
+
+namespace JiraToRea.App;
+
+public sealed class WorklogStatisticsForm : Form
+{
+    public WorklogStatisticsForm(IReadOnlyCollection<WorklogEntryViewModel> entries)
+    {
+        if (entries is null)
+        {
+            throw new ArgumentNullException(nameof(entries));
+        }
+
+        Text = "Meraklısına İstatistik";
+        StartPosition = FormStartPosition.CenterParent;
+        MinimumSize = new Size(700, 500);
+        Font = new Font("Segoe UI", 9F, FontStyle.Regular, GraphicsUnit.Point);
+
+        var tabControl = new TabControl
+        {
+            Dock = DockStyle.Fill
+        };
+
+        Controls.Add(tabControl);
+
+        var totalHours = entries.Sum(entry => entry.EffortHours);
+        var dailyTotals = entries
+            .GroupBy(entry => entry.StartDate.Date)
+            .Select(group => new DailyTotal(group.Key, group.Sum(entry => entry.EffortHours)))
+            .OrderBy(total => total.Date)
+            .ToList();
+
+        var taskTotals = entries
+            .GroupBy(entry => string.IsNullOrWhiteSpace(entry.Task) ? "(Görev Yok)" : entry.Task.Trim())
+            .Select(group => new TaskTotal(group.Key, group.Sum(entry => entry.EffortHours)))
+            .OrderByDescending(total => total.Hours)
+            .ThenBy(total => total.Task, StringComparer.CurrentCultureIgnoreCase)
+            .ToList();
+
+        BuildTotalTab(tabControl, totalHours);
+        BuildDailyTotalsTab(tabControl, dailyTotals);
+        BuildTaskTotalsTab(tabControl, taskTotals);
+    }
+
+    private void BuildTotalTab(TabControl tabControl, double totalHours)
+    {
+        var tabPage = new TabPage("Toplam");
+
+        var totalLabel = new Label
+        {
+            Text = $"Toplam\n{totalHours:N2} saat",
+            Dock = DockStyle.Fill,
+            TextAlign = ContentAlignment.MiddleCenter,
+            Font = new Font(Font.FontFamily, 36F, FontStyle.Bold, GraphicsUnit.Point)
+        };
+
+        tabPage.Controls.Add(totalLabel);
+        tabControl.TabPages.Add(tabPage);
+    }
+
+    private void BuildDailyTotalsTab(TabControl tabControl, IReadOnlyList<DailyTotal> dailyTotals)
+    {
+        var tabPage = new TabPage("Günlük");
+
+        if (dailyTotals.Count == 0)
+        {
+            tabPage.Controls.Add(CreateEmptyLabel("Günlük toplam bulunmuyor."));
+            tabControl.TabPages.Add(tabPage);
+            return;
+        }
+
+        var calendarLayout = CreateCalendarLayout(dailyTotals);
+        tabPage.Controls.Add(calendarLayout);
+        tabControl.TabPages.Add(tabPage);
+    }
+
+    private Control CreateCalendarLayout(IReadOnlyList<DailyTotal> dailyTotals)
+    {
+        var culture = CultureInfo.CurrentCulture;
+        var firstDayOfWeek = culture.DateTimeFormat.FirstDayOfWeek;
+
+        var minDate = dailyTotals.First().Date;
+        var maxDate = dailyTotals.Last().Date;
+
+        var startDate = minDate;
+        var endDate = maxDate;
+
+        var startCalendarDate = startDate;
+        while (startCalendarDate.DayOfWeek != firstDayOfWeek)
+        {
+            startCalendarDate = startCalendarDate.AddDays(-1);
+        }
+
+        var endCalendarDate = endDate;
+        var lastDayOfWeek = (DayOfWeek)(((int)firstDayOfWeek + 6) % 7);
+        while (endCalendarDate.DayOfWeek != lastDayOfWeek)
+        {
+            endCalendarDate = endCalendarDate.AddDays(1);
+        }
+
+        var totalsByDate = dailyTotals.ToDictionary(total => total.Date, total => total.Hours);
+
+        var table = new TableLayoutPanel
+        {
+            Dock = DockStyle.Fill,
+            ColumnCount = 7,
+            RowCount = 1,
+            BackColor = Color.White,
+            Padding = new Padding(8),
+            AutoScroll = true
+        };
+
+        for (var i = 0; i < 7; i++)
+        {
+            table.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100f / 7f));
+        }
+
+        table.RowStyles.Add(new RowStyle(SizeType.Absolute, 30f));
+
+        for (var i = 0; i < 7; i++)
+        {
+            var dayIndex = ((int)firstDayOfWeek + i) % 7;
+            var headerLabel = new Label
+            {
+                Text = culture.DateTimeFormat.AbbreviatedDayNames[dayIndex],
+                Dock = DockStyle.Fill,
+                TextAlign = ContentAlignment.MiddleCenter,
+                Font = new Font(Font, FontStyle.Bold)
+            };
+
+            table.Controls.Add(headerLabel, i, 0);
+        }
+
+        var totalDays = (endCalendarDate - startCalendarDate).Days + 1;
+        var weekCount = (int)Math.Ceiling(totalDays / 7.0);
+
+        table.RowCount = weekCount + 1;
+
+        for (var i = 0; i < weekCount; i++)
+        {
+            table.RowStyles.Add(new RowStyle(SizeType.Percent, 100f / Math.Max(1, weekCount)));
+        }
+
+        var currentDate = startCalendarDate;
+        for (var week = 0; week < weekCount; week++)
+        {
+            for (var day = 0; day < 7; day++)
+            {
+                var cellPanel = new Panel
+                {
+                    Dock = DockStyle.Fill,
+                    Margin = new Padding(4),
+                    BackColor = Color.White,
+                    BorderStyle = BorderStyle.FixedSingle
+                };
+
+                var dayLabel = new Label
+                {
+                    Text = currentDate.Day.ToString(culture),
+                    Dock = DockStyle.Top,
+                    TextAlign = ContentAlignment.TopLeft,
+                    Padding = new Padding(4, 4, 4, 0),
+                    Font = new Font(Font, FontStyle.Bold)
+                };
+
+                var hoursLabel = new Label
+                {
+                    Text = totalsByDate.TryGetValue(currentDate, out var value) ? $"{value:N2} saat" : string.Empty,
+                    Dock = DockStyle.Fill,
+                    TextAlign = ContentAlignment.MiddleCenter,
+                    Font = new Font(Font, FontStyle.Regular)
+                };
+
+                if (currentDate < minDate || currentDate > maxDate)
+                {
+                    dayLabel.ForeColor = SystemColors.GrayText;
+                    hoursLabel.ForeColor = SystemColors.GrayText;
+                }
+
+                cellPanel.Controls.Add(hoursLabel);
+                cellPanel.Controls.Add(dayLabel);
+
+                table.Controls.Add(cellPanel, day, week + 1);
+
+                currentDate = currentDate.AddDays(1);
+            }
+        }
+
+        return table;
+    }
+
+    private void BuildTaskTotalsTab(TabControl tabControl, IReadOnlyList<TaskTotal> taskTotals)
+    {
+        var tabPage = new TabPage("Task Bazında");
+
+        if (taskTotals.Count == 0)
+        {
+            tabPage.Controls.Add(CreateEmptyLabel("Task bazında toplam bulunmuyor."));
+            tabControl.TabPages.Add(tabPage);
+            return;
+        }
+
+        var grid = new DataGridView
+        {
+            Dock = DockStyle.Fill,
+            AutoGenerateColumns = false,
+            AllowUserToAddRows = false,
+            AllowUserToDeleteRows = false,
+            ReadOnly = true,
+            SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+            MultiSelect = false
+        };
+
+        var taskColumn = new DataGridViewTextBoxColumn
+        {
+            DataPropertyName = nameof(TaskTotalRow.Task),
+            HeaderText = "Task",
+            AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
+        };
+
+        var hoursColumn = new DataGridViewTextBoxColumn
+        {
+            DataPropertyName = nameof(TaskTotalRow.TotalHours),
+            HeaderText = "Toplam Saat",
+            Width = 120,
+            DefaultCellStyle = new DataGridViewCellStyle
+            {
+                Format = "N2",
+                Alignment = DataGridViewContentAlignment.MiddleRight
+            }
+        };
+
+        grid.Columns.Add(taskColumn);
+        grid.Columns.Add(hoursColumn);
+
+        var bindingList = new BindingList<TaskTotalRow>(taskTotals
+            .Select(total => new TaskTotalRow(total.Task, total.Hours))
+            .ToList());
+
+        grid.DataSource = bindingList;
+
+        tabPage.Controls.Add(grid);
+        tabControl.TabPages.Add(tabPage);
+    }
+
+    private Control CreateEmptyLabel(string text)
+    {
+        return new Label
+        {
+            Text = text,
+            Dock = DockStyle.Fill,
+            TextAlign = ContentAlignment.MiddleCenter
+        };
+    }
+
+    private sealed record DailyTotal(DateTime Date, double Hours);
+
+    private sealed record TaskTotal(string Task, double Hours);
+
+    private sealed class TaskTotalRow
+    {
+        public TaskTotalRow(string task, double totalHours)
+        {
+            Task = task;
+            TotalHours = totalHours;
+        }
+
+        public string Task { get; }
+
+        public double TotalHours { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the statistics message box with a dedicated form opened from the main window
- show the overall total, daily calendar-style breakdown, and task-level totals in separate tabs

## Testing
- (not run) dotnet build

------
https://chatgpt.com/codex/tasks/task_e_68e3848ca5e083229000219bf41ad56f