### PR TITLE
Use response envelope model when loading Rea projects

### DIFF
--- a/src/JiraToRea.App/Models/ReaModels.cs
+++ b/src/JiraToRea.App/Models/ReaModels.cs
@@ -4,6 +4,21 @@ using JiraToRea.App.Serialization;
 
 namespace JiraToRea.App.Models;
 
+public sealed class ReaApiResponse<T>
+{
+    [JsonPropertyName("data")]
+    public T? Data { get; init; }
+
+    [JsonPropertyName("message")]
+    public string? Message { get; init; }
+
+    [JsonPropertyName("status")]
+    public int Status { get; init; }
+
+    [JsonPropertyName("isSuccess")]
+    public bool IsSuccess { get; init; }
+}
+
 public sealed class ReaLoginRequest
 {
     [JsonPropertyName("userName")]
@@ -76,4 +91,39 @@ public sealed class ReaProject
         : $"{Code} - {Name}";
 
     public override string ToString() => DisplayName;
+}
+
+public sealed class ReaProjectPayload
+{
+    [JsonPropertyName("projectId")]
+    [JsonConverter(typeof(FlexibleStringJsonConverter))]
+    public string? ProjectId { get; init; }
+
+    [JsonPropertyName("id")]
+    [JsonConverter(typeof(FlexibleStringJsonConverter))]
+    public string? Id { get; init; }
+
+    [JsonPropertyName("projectName")]
+    public string? ProjectName { get; init; }
+
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+
+    [JsonPropertyName("projectCode")]
+    public string? ProjectCode { get; init; }
+
+    [JsonPropertyName("code")]
+    public string? Code { get; init; }
+
+    [JsonPropertyName("shortName")]
+    public string? ShortName { get; init; }
+
+    [JsonPropertyName("key")]
+    public string? Key { get; init; }
+
+    [JsonPropertyName("projectKey")]
+    public string? ProjectKey { get; init; }
 }

--- a/src/JiraToRea.App/Serialization/FlexibleStringJsonConverter.cs
+++ b/src/JiraToRea.App/Serialization/FlexibleStringJsonConverter.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace JiraToRea.App.Serialization;
+
+public sealed class FlexibleStringJsonConverter : JsonConverter<string?>
+{
+    public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        switch (reader.TokenType)
+        {
+            case JsonTokenType.String:
+                return reader.GetString();
+            case JsonTokenType.Number:
+            case JsonTokenType.True:
+            case JsonTokenType.False:
+                return reader.GetRawText();
+            case JsonTokenType.Null:
+            case JsonTokenType.Undefined:
+                return null;
+            case JsonTokenType.StartObject:
+            case JsonTokenType.StartArray:
+                using (var document = JsonDocument.ParseValue(ref reader))
+                {
+                    return document.RootElement.GetRawText();
+                }
+            default:
+                throw new JsonException($"Unsupported token type '{reader.TokenType}' for flexible string conversion.");
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, string? value, JsonSerializerOptions options)
+    {
+        if (value is null)
+        {
+            writer.WriteNullValue();
+            return;
+        }
+
+        writer.WriteStringValue(value);
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable response envelope model and project payload mappings for the Rea API
- introduce a flexible string converter to read identifiers regardless of their JSON type
- update project retrieval to deserialize the envelope before falling back to the resilient parser

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e38d794c948322bb91379103dd6f88