### PR TITLE
Handle nested JSON strings in Rea project parsing

### DIFF
--- a/src/JiraToRea.App/Services/ReaApiClient.cs
+++ b/src/JiraToRea.App/Services/ReaApiClient.cs
@@ -257,21 +257,45 @@ public sealed class ReaApiClient : IDisposable
 
                 foreach (var property in element.EnumerateObject())
                 {
+                    if (property.Value.ValueKind == JsonValueKind.String &&
+                        TryParseJsonElement(property.Value.GetString(), out var stringElement))
+                    {
+                        foreach (var nested in EnumerateProjectObjects(stringElement))
+                        {
+                            yield return nested;
+                        }
+
+                        continue;
+                    }
+
                     foreach (var nested in EnumerateProjectObjects(property.Value))
                     {
                         yield return nested;
                     }
                 }
+
                 break;
 
             case JsonValueKind.Array:
                 foreach (var item in element.EnumerateArray())
                 {
+                    if (item.ValueKind == JsonValueKind.String &&
+                        TryParseJsonElement(item.GetString(), out var arrayItemElement))
+                    {
+                        foreach (var nested in EnumerateProjectObjects(arrayItemElement))
+                        {
+                            yield return nested;
+                        }
+
+                        continue;
+                    }
+
                     foreach (var nested in EnumerateProjectObjects(item))
                     {
                         yield return nested;
                     }
                 }
+
                 break;
         }
     }
@@ -363,6 +387,27 @@ public sealed class ReaApiClient : IDisposable
         }
 
         return value.Trim();
+    }
+
+    private static bool TryParseJsonElement(string? candidate, out JsonElement element)
+    {
+        element = default;
+
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return false;
+        }
+
+        try
+        {
+            using var document = JsonDocument.Parse(candidate);
+            element = document.RootElement.Clone();
+            return true;
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
     }
 
     private static bool IsPropertyName(string actual, string expected)


### PR DESCRIPTION
## Summary
- extend Rea project enumeration to detect project objects inside stringified JSON payloads
- add a helper that safely parses candidate JSON strings before recursing through the response structure

## Testing
- not run (dotnet CLI not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e38dc2902c8322947f57664e8e1aa3