### PR TITLE
Use new Rea project list endpoint

### DIFF
--- a/src/JiraToRea.App/MainForm.cs
+++ b/src/JiraToRea.App/MainForm.cs
@@ -597,7 +597,7 @@ public sealed class MainForm : Form
             var profile = await _reaClient.GetUserProfileAsync().ConfigureAwait(true);
             _reaUserIdTextBox.Text = profile.UserId;
 
-            var projects = await _reaClient.GetProjectsAsync(profile.UserId).ConfigureAwait(true);
+            var projects = await _reaClient.GetProjectsAsync().ConfigureAwait(true);
 
             _reaProjects.Clear();
             foreach (var project in projects.OrderBy(p => p.DisplayName, StringComparer.CurrentCultureIgnoreCase))

--- a/src/JiraToRea.App/Services/ReaApiClient.cs
+++ b/src/JiraToRea.App/Services/ReaApiClient.cs
@@ -14,7 +14,7 @@ public sealed class ReaApiClient : IDisposable
 {
     private const string LoginEndpoint = "api/Auth/Login";
     private const string UserProfileEndpoint = "api/Auth/GetUserProfileInfo";
-    private const string ProjectListEndpoint = "api/Project/GetAllProjectWithProp";
+    private const string ProjectListEndpoint = "api/Project/GetAll";
     private const string TimeEntryEndpoint = "api/TimeSheet/Create";
 
     private readonly HttpClient _httpClient;
@@ -70,16 +70,13 @@ public sealed class ReaApiClient : IDisposable
         return new ReaUserProfile(userId, name);
     }
 
-    public async Task<IReadOnlyList<ReaProject>> GetProjectsAsync(string userId, CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyList<ReaProject>> GetProjectsAsync(string? userId = null, CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(userId))
-        {
-            throw new ArgumentException("User ID is required to load projects.", nameof(userId));
-        }
-
         EnsureAuthenticated();
 
-        var requestUri = $"{ProjectListEndpoint}?userId={Uri.EscapeDataString(userId)}";
+        var requestUri = string.IsNullOrWhiteSpace(userId)
+            ? ProjectListEndpoint
+            : $"{ProjectListEndpoint}?userId={Uri.EscapeDataString(userId)}";
         using var response = await _httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
         var responseBody = await EnsureSuccessAndReadContentAsync(response, "retrieve the Rea project list", cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary
- update the Rea API client to call the new `api/Project/GetAll` endpoint
- allow loading the project list without a userId and update the UI to use the relaxed signature

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3946de7e4832292c9a537ab6c2206