### PR TITLE
Clear grid selection after loading worklogs

### DIFF
--- a/src/JiraToRea.App/MainForm.cs
+++ b/src/JiraToRea.App/MainForm.cs
@@ -508,6 +508,8 @@ public sealed class MainForm : Form
                 _worklogEntries.Add(entry);
             }
 
+            _worklogGrid.ClearSelection();
+            UpdateSelectionInfo();
             SetStatus($"{worklogs.Count} adet worklog yüklendi.");
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- clear the worklog grid selection after loading Jira entries so the UI starts with zero selected rows
- refresh the selection info immediately to keep the status label consistent with the grid state

## Testing
- not run (GUI app / no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68e395a5cf148322a037320fdc52c0f9