### PR TITLE
Add file-based logging for time entry imports

### DIFF
--- a/src/JiraToRea.App/MainForm.cs
+++ b/src/JiraToRea.App/MainForm.cs
@@ -16,6 +16,7 @@ public sealed class MainForm : Form
     private readonly ReaApiClient _reaClient = new();
     private readonly JiraApiClient _jiraClient = new();
     private readonly UserSettingsService _settingsService = new();
+    private readonly ImportLogger _importLogger = new();
     private readonly BindingList<WorklogEntryViewModel> _worklogEntries = new();
     private readonly BindingList<ReaProject> _reaProjects = new();
 
@@ -604,10 +605,12 @@ public sealed class MainForm : Form
                 await _reaClient.CreateTimeEntryAsync(timeEntry).ConfigureAwait(true);
             }
 
+            _importLogger.LogImport(userId, projectId, entries, success: true);
             SetStatus($"{entries.Count} kayıt Rea portalına gönderildi.");
         }
         catch (Exception ex)
         {
+            _importLogger.LogImport(userId, projectId, entries, success: false, errorMessage: ex.Message);
             MessageBox.Show(this, ex.Message, "Rea Portal", MessageBoxButtons.OK, MessageBoxIcon.Error);
             SetStatus("Rea portal aktarımı sırasında hata oluştu.");
         }

--- a/src/JiraToRea.App/Services/ImportLogger.cs
+++ b/src/JiraToRea.App/Services/ImportLogger.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using JiraToRea.App.Models;
+
+namespace JiraToRea.App.Services;
+
+public sealed class ImportLogger
+{
+    private readonly string _logFilePath;
+    private readonly object _syncRoot = new();
+
+    public ImportLogger()
+    {
+        var baseDirectory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "JiraToRea",
+            "Logs");
+
+        Directory.CreateDirectory(baseDirectory);
+        _logFilePath = Path.Combine(baseDirectory, "import.log");
+    }
+
+    public void LogImport(string userId, string projectId, IReadOnlyCollection<WorklogEntryViewModel> entries, bool success, string? errorMessage = null)
+    {
+        try
+        {
+            var logEntry = BuildLogEntry(userId, projectId, entries, success, errorMessage);
+
+            lock (_syncRoot)
+            {
+                File.AppendAllText(_logFilePath, logEntry, Encoding.UTF8);
+            }
+        }
+        catch
+        {
+            // Logging failures should not interrupt the application flow.
+        }
+    }
+
+    private static string BuildLogEntry(string userId, string projectId, IReadOnlyCollection<WorklogEntryViewModel> entries, bool success, string? errorMessage)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine(new string('-', 80));
+        builder.AppendLine($"Timestamp: {DateTime.Now:yyyy-MM-dd HH:mm:ss}");
+        builder.AppendLine($"Result: {(success ? "Success" : "Failure")}");
+        builder.AppendLine($"User ID: {userId}");
+        builder.AppendLine($"Project ID: {projectId}");
+        builder.AppendLine($"Entry Count: {entries.Count}");
+
+        var index = 1;
+        foreach (var entry in entries)
+        {
+            builder.AppendLine($"#{index} | Issue: {entry.IssueKey} | Task: {entry.Task} | Start: {entry.StartDate:yyyy-MM-dd HH:mm} | End: {entry.EndDate:yyyy-MM-dd HH:mm} | Effort: {entry.EffortHours:0.##} | Comment: {entry.Comment}");
+            index++;
+        }
+
+        if (!success && !string.IsNullOrWhiteSpace(errorMessage))
+        {
+            builder.AppendLine($"Error: {errorMessage}");
+        }
+
+        builder.AppendLine();
+        return builder.ToString();
+    }
+}


### PR DESCRIPTION
## Summary
- add a file-based import logger that records attempts in the user's local application data folder
- capture successful and failed Rea portal submissions with timestamps, parameters and entry counts
- integrate the logger into the import workflow so every batch submission is logged

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e3963ecbe883228d9359c2bc684019