### PR TITLE
Streamline Rea time entry deserialization

### DIFF
--- a/src/JiraToRea.App/Models/ReaModels.cs
+++ b/src/JiraToRea.App/Models/ReaModels.cs
@@ -34,9 +34,11 @@ public sealed class ReaTimeEntry
     public int Id { get; set; }
 
     [JsonPropertyName("userId")]
+    [JsonConverter(typeof(FlexibleStringJsonConverter))]
     public string UserId { get; set; } = string.Empty;
 
     [JsonPropertyName("projectId")]
+    [JsonConverter(typeof(FlexibleStringJsonConverter))]
     public string ProjectId { get; set; } = string.Empty;
 
     [JsonPropertyName("task")]


### PR DESCRIPTION
## Summary
- avoid per-item deserialization when retrieving Rea time entries
- centralize time entry parsing into reusable helpers that handle envelopes, arrays, and single objects

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a7f1c00c8322922d80444585eb20